### PR TITLE
Disable `BuildOptions.DetailedBuildReport` with `BUILDMAGIC_NO_DETAILED_BUILD_REPORT`

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildPlayerOptionsBuilder.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildPlayerOptionsBuilder.cs
@@ -107,6 +107,12 @@ namespace BuildMagicEditor
         /// </summary>
         public BuildPlayerOptions Build()
         {
+            var options = _options;
+
+#if BUILDMAGIC_NO_DETAILED_BUILD_REPORT
+            options &= ~BuildOptions.DetailedBuildReport;
+#endif
+
             return new BuildPlayerOptions
             {
                 locationPathName = string.IsNullOrWhiteSpace(_locationPathName) ? GetDefaultBuildPath(_buildTarget) : _locationPathName,
@@ -115,7 +121,7 @@ namespace BuildMagicEditor
                 target = _buildTarget,
                 targetGroup = _buildTargetGroup,
                 subtarget = _subtarget,
-                options = _options,
+                options = options,
                 extraScriptingDefines = _extraScriptingDefines.ToArray()
             };
         }


### PR DESCRIPTION
Closes #6 
BuildMagic は既定で BuildOptions.DetailedBuildReport を使用しますが、ビルド時にエディタがクラッシュする場合があるので、`BUILDMAGIC_NO_DETAILED_BUILD_REPORT` で無効化できるようにします。

https://discussions.unity.com/t/buildpipeline-buildplayer-with-detailedbuildreport-crashes-unity-2022-3-14-15-2023-2-3/935854