### PR TITLE
Make internal prepare phase visible with an option

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Assets/Uxml/RightPane.uxml
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Assets/Uxml/RightPane.uxml
@@ -11,7 +11,7 @@
             <ui:Foldout text="Pre-build" name="pre-build-configuration-foldout" class="configuration-list-foldout">
                 <BuildMagic.Window.Editor.Elements.ConfigurationListView configuration-type="PreBuild" class="configuration-list-view-root" />
             </ui:Foldout>
-            <ui:Foldout text="Internal Prepare" name="internal-prepare-configuration-foldout" class="configuration-list-foldout">
+            <ui:Foldout text="Just before the build" name="internal-prepare-configuration-foldout" class="configuration-list-foldout">
                 <BuildMagic.Window.Editor.Elements.ConfigurationListView configuration-type="InternalPrepare" class="configuration-list-view-root" />
             </ui:Foldout>
             <ui:Foldout text="Post-build" name="post-build-configuration-foldout" class="configuration-list-foldout">

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowModel.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowModel.cs
@@ -222,11 +222,9 @@ namespace BuildMagic.Window.Editor
                 case ConfigurationType.PreBuild:
                     _selected.Self.AddPreBuildConfiguration(configuration);
                     break;
-#if BUILDMAGIC_DEVELOPER
                 case ConfigurationType.InternalPrepare:
-                    _selected.AddInternalPrepareConfiguration(configuration);
+                    _selected.Self.AddInternalPrepareConfiguration(configuration);
                     break;
-#endif
                 case ConfigurationType.PostBuild:
                     _selected.Self.AddPostBuildConfiguration(configuration);
                     break;
@@ -250,9 +248,7 @@ namespace BuildMagic.Window.Editor
             var targetList = configurationType switch
             {
                 ConfigurationType.PreBuild => _selected.Self.PreBuildConfigurations,
-#if BUILDMAGIC_DEVELOPER
                 ConfigurationType.InternalPrepare => _selected.Self.InternalPrepareConfigurations,
-#endif
                 ConfigurationType.PostBuild => _selected.Self.PostBuildConfigurations,
                 _ => throw new ArgumentOutOfRangeException(nameof(configurationType), configurationType, null)
             };
@@ -263,11 +259,9 @@ namespace BuildMagic.Window.Editor
                 case ConfigurationType.PreBuild:
                     _selected.Self.RemovePreBuildConfiguration(index);
                     break;
-#if BUILDMAGIC_DEVELOPER
                 case ConfigurationType.InternalPrepare:
                     _selected.Self.RemovePrepareBuildPlayerConfiguration(index);
                     break;
-#endif
                 case ConfigurationType.PostBuild:
                     _selected.Self.RemovePostBuildConfiguration(index);
                     break;
@@ -290,9 +284,7 @@ namespace BuildMagic.Window.Editor
 
             var list = new List<Type>();
             list.AddRange(_selected.Self.PreBuildConfigurations.Select(c => c.GetType()));
-#if BUILDMAGIC_DEVELOPER
-            list.AddRange(_selected.InternalPrepareConfigurations.Select(c => c.GetType()));
-#endif
+            list.AddRange(_selected.Self.InternalPrepareConfigurations.Select(c => c.GetType()));
             list.AddRange(_selected.Self.PostBuildConfigurations.Select(c => c.GetType()));
             return list.ToHashSet();
         }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Drawers/SerializableDictionaryDrawer.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Drawers/SerializableDictionaryDrawer.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BuildMagic.Window.Editor.Elements;
+using BuildMagic.Window.Editor.Utilities;
 using BuildMagicEditor;
 using UnityEditor;
 using UnityEditor.UIElements;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
@@ -4,6 +4,7 @@
 
 using System;
 using BuildMagic.Window.Editor.SubWindows;
+using BuildMagic.Window.Editor.Utilities;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine.Assertions;
@@ -34,12 +35,21 @@ namespace BuildMagic.Window.Editor.Elements
             toolbarMenu.menu.AppendAction("Remove the selected build scheme",
                 _ => RemoveRequested?.Invoke(string.Empty),
                 OnMenuActionStatus);
-            toolbarMenu.menu.AppendAction("Switch to the selected build scheme", _ => PreBuildRequested?.Invoke(),
+            toolbarMenu.menu.AppendAction("Run Pre-build phase of the selected build scheme",
+                _ => PreBuildRequested?.Invoke(),
                 OnMenuActionStatus);
             toolbarMenu.menu.AppendAction("Build with the selected scheme", _ => BuildRequested?.Invoke(),
                 OnMenuActionStatus);
             toolbarMenu.menu.AppendSeparator();
             toolbarMenu.menu.AppendAction("Open diff window", _ => DiffWindow.Open());
+            toolbarMenu.menu.AppendAction("Enable \"Just before the build\" phase (advanced)", _ =>
+                {
+                    var v = UserSettings.EnableInternalPrepareEditor;
+                    v.Value = !v.Value;
+                },
+                _ => UserSettings.EnableInternalPrepareEditor.Value
+                    ? DropdownMenuAction.Status.Checked
+                    : DropdownMenuAction.Status.Normal);
 
             _treeView = this.Q<LeftPaneTreeView>();
             Assert.IsNotNull(_treeView);

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
@@ -3,10 +3,11 @@
 // --------------------------------------------------------------
 
 using System;
-using System.Collections;
+using System.Reflection;
+using BuildMagic.Window.Editor.Foundation.TinyRx;
+using BuildMagic.Window.Editor.Utilities;
 using BuildMagicEditor;
 using UnityEditor;
-using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.Serialization;
@@ -17,16 +18,17 @@ namespace BuildMagic.Window.Editor.Elements
     internal sealed class RightPaneView : VisualElement, IRightPaneView
     {
         private readonly Button _addConfigurationButton;
+        private readonly Foldout _internalPrepareConfigurationFoldout;
 
         public RightPaneView()
         {
             var visualTree = AssetLoader.LoadUxml("RightPane");
             Assert.IsNotNull(visualTree);
             visualTree.CloneTree(this);
-            
+
             _addConfigurationButton = this.Q<Button>("add-configuration-button");
             Assert.IsNotNull(_addConfigurationButton);
-            _addConfigurationButton.clickable.clicked += () => AddRequested?.Invoke(_addConfigurationButton.layout);;
+            _addConfigurationButton.clickable.clicked += () => AddRequested?.Invoke(_addConfigurationButton.layout);
 
             var bindableElement = this.Q<BindableElement>("container");
             Assert.IsNotNull(bindableElement);
@@ -39,6 +41,25 @@ namespace BuildMagic.Window.Editor.Elements
             var linkBase = this.Q<SchemeLinkLabel>("link-base");
             Assert.IsNotNull(linkBase);
             linkBase.bindingPath = "_baseSchemeName";
+
+            _internalPrepareConfigurationFoldout = this.Q<Foldout>("internal-prepare-configuration-foldout");
+
+            // interactable though disabled
+            typeof(Clickable).GetProperty("acceptClicksIfDisabled", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(
+                    typeof(Toggle).GetField("m_Clickable", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(
+                        typeof(Foldout).GetProperty("toggle", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(
+                            _internalPrepareConfigurationFoldout))
+                    , true);
+
+            UserSettings.EnableInternalPrepareEditor.Subscribe(enabled =>
+            {
+                _internalPrepareConfigurationFoldout.SetEnabled(enabled);
+                // show if enabled
+                if (enabled)
+                    _internalPrepareConfigurationFoldout.style.display =
+                        new StyleEnum<DisplayStyle>(StyleKeyword.Undefined);
+            });
         }
 
         public event Action<Rect> AddRequested;
@@ -54,12 +75,24 @@ namespace BuildMagic.Window.Editor.Elements
             if (selectedSchemeProp.managedReferenceId is ManagedReferenceUtility.RefIdUnknown
                 or ManagedReferenceUtility.RefIdNull) return;
 
+            var hasAnyInternalPrepareConfigurations = false;
             foreach (var configurationListView in this.Query<ConfigurationListView>()
                          .Class("configuration-list-view-root").Build())
+            {
                 configurationListView.Bind(selectedSchemeProp,
-                    (type, index, configuration) => RemoveRequested?.Invoke(type, index, configuration));
+                    (type, index, configuration) => RemoveRequested?.Invoke(type, index, configuration),
+                    out var hasAny);
+                if (configurationListView.Type == ConfigurationType.InternalPrepare)
+                    hasAnyInternalPrepareConfigurations = hasAny;
+            }
+
+            // if the selected scheme has at least one internal prepare configuration at this time, just display the foldout (but not editable)
+            if (!UserSettings.EnableInternalPrepareEditor.Value)
+                _internalPrepareConfigurationFoldout.style.display = hasAnyInternalPrepareConfigurations
+                    ? new StyleEnum<DisplayStyle>(StyleKeyword.Undefined)
+                    : DisplayStyle.None;
         }
-        
+
         public new class UxmlFactory : UxmlFactory<RightPaneView, UxmlTraits>
         {
         }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/BuildPlatformWrapper.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/BuildPlatformWrapper.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 using UnityEditor.Build;
 using UnityEngine;
 
-namespace BuildMagic.Window.Editor.Elements
+namespace BuildMagic.Window.Editor.Utilities
 {
     internal readonly struct BuildPlatformWrapper : IEquatable<BuildPlatformWrapper>
     {

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/UserSettings.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/UserSettings.cs
@@ -1,0 +1,27 @@
+// --------------------------------------------------------------
+// Copyright 2025 CyberAgent, Inc.
+// --------------------------------------------------------------
+
+using BuildMagic.Window.Editor.Foundation.TinyRx;
+using BuildMagic.Window.Editor.Foundation.TinyRx.ObservableProperty;
+using UnityEditor;
+
+namespace BuildMagic.Window.Editor.Utilities
+{
+    public static class UserSettings
+    {
+        static UserSettings()
+        {
+            EnableInternalPrepareEditor = RegisterBool("BuildMagic.EnableInternalPrepareEditor", false);
+        }
+
+        public static ObservableProperty<bool> EnableInternalPrepareEditor { get; }
+
+        private static ObservableProperty<bool> RegisterBool(string key, bool defaultValue)
+        {
+            var result = new ObservableProperty<bool>(EditorPrefs.GetBool(key, defaultValue));
+            result.Subscribe(value => EditorPrefs.SetBool(key, value));
+            return result;
+        }
+    }
+}

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/UserSettings.cs.meta
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/UserSettings.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f3d89f48b25b4cc6b76f6277d5f27ace
+timeCreated: 1738748620

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildScheme.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildScheme.cs
@@ -12,7 +12,7 @@ namespace BuildMagicEditor
     ///     The build scheme.
     /// </summary>
     [Serializable]
-    public class BuildScheme : IBuildScheme
+    public class BuildScheme : IBuildScheme, ISerializationCallbackReceiver
     {
         [SerializeField] private string _name;
         [SerializeReference] private List<IBuildConfiguration> _postBuildConfigurations = new();
@@ -71,6 +71,23 @@ namespace BuildMagicEditor
         internal void RemovePostBuildConfiguration(int index)
         {
             _postBuildConfigurations.RemoveAt(index);
+        }
+
+        public void OnBeforeSerialize()
+        {
+            RemoveNulls();
+        }
+
+        public void OnAfterDeserialize()
+        {
+            RemoveNulls();
+        }
+
+        private void RemoveNulls()
+        {
+            _postBuildConfigurations.RemoveAll(configuration => configuration == null);
+            _internalPrepareConfigurations.RemoveAll(configuration => configuration == null);
+            _preBuildConfigurations.RemoveAll(configuration => configuration == null);
         }
     }
 }


### PR DESCRIPTION
"Internal Prepare" phase, which is a phase run before the player build and only available for internal use, is renamed to "Just before the build" and is made (opt-in) visible for all users.

## Usage

- Enable "Just Before the Build" phase from BuildMagic window menu.

<img width="699" alt="image" src="https://github.com/user-attachments/assets/f08cdff2-96a8-4399-9a87-ac36da6c9f16" /><br />


- "Just Before the Build" phase will be visible.

<img width="568" alt="image" src="https://github.com/user-attachments/assets/eb526cd7-f482-48ea-8b6b-4b2fb6f6e856" /><br />


- If "Just Before the Build" has any configurations (including derived) but disabled, the phase is visible but read-only.

<img width="568" alt="image" src="https://github.com/user-attachments/assets/eb2b3ff9-c061-4c95-830f-3e449c9e070f" /><br />

## Note

- Class and interface name of `InternalPrepare` is not changed. It only affects displayed names.
- Whether the phase is enabled is saved to the machine.