### PR TITLE
Fix output path isn't set correctly when built through Build Settings window

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildPlayerWindowHook.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildPlayerWindowHook.cs
@@ -59,6 +59,9 @@ namespace BuildMagicEditor
 
                 var overrideOptions = internalPrepareTasks.GenerateBuildPlayerOptions();
 
+                // Apply default options such as AutoRunPlayer
+                overrideOptions.options |= options.options;
+
                 if (!PickBuildLocation(overrideOptions.targetGroup, overrideOptions.target, overrideOptions.subtarget,
                         overrideOptions.options, out var updateExistingBuild))
                     throw new OperationCanceledException();

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildPlayerWindowHook.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildPlayerWindowHook.cs
@@ -64,10 +64,10 @@ namespace BuildMagicEditor
                     throw new OperationCanceledException();
 
                 if (updateExistingBuild)
-                    options.options |= BuildOptions.AcceptExternalModificationsToPlayer;
+                    overrideOptions.options |= BuildOptions.AcceptExternalModificationsToPlayer;
 
                 // PickBuildLocationの結果を反映
-                options.locationPathName = EditorUserBuildSettings.GetBuildLocation(overrideOptions.target);
+                overrideOptions.locationPathName = EditorUserBuildSettings.GetBuildLocation(overrideOptions.target);
 
                 return overrideOptions;
             });


### PR DESCRIPTION
Fixed the issue that output location is not set to the selected path when an user requests the build with BuildMagic from Build Settings window.