### PR TITLE
Fix derived and "Just before the build" configurations are ignored

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Commandline/Editor/BuildMagicCLI.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Commandline/Editor/BuildMagicCLI.cs
@@ -107,11 +107,17 @@ public static class BuildMagicCLI
         var setConfigurationPathTaskBuilder =
             context.TaskBuilderProvider.GetBuilder(setLocationPathConfiguration.TaskType, property.ValueType);
 
+        var configurations =
+            BuildSchemeUtility.EnumerateComposedConfigurations<IInternalPrepareContext>(context
+                .InheritanceTreeFromLeafToRoot);
+
         List<IBuildTask<IInternalPrepareContext>> tasks = new()
         {
             new BuildPlayerOptionsApplyEditorSettingsTask(),
             setConfigurationPathTaskBuilder.Build(property.Value) as IBuildTask<IInternalPrepareContext>
         };
+
+        tasks.AddRange(BuildTaskBuilderUtility.CreateBuildTasks<IInternalPrepareContext>(configurations));
 
         tasks.AddRange(GetUnresolvedOverrideProperties(context).OfType<IBuildTask<IInternalPrepareContext>>());
 

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowModel.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowModel.cs
@@ -130,7 +130,8 @@ namespace BuildMagic.Window.Editor
             internalPrepareTasks.Add(new BuildPlayerOptionsApplyEditorSettingsTask());
             internalPrepareTasks.AddRange(
                 BuildTaskBuilderUtility.CreateBuildTasks<IInternalPrepareContext>(
-                    _selected.Self.InternalPrepareConfigurations));
+                    BuildSchemeUtility.EnumerateComposedConfigurations<IInternalPrepareContext>(_selected.Self,
+                        _schemes)));
 
             var configurations =
                 BuildSchemeUtility.EnumerateComposedConfigurations<IPostBuildContext>(_selected.Self, _schemes);

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildMagicSettings.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildMagicSettings.cs
@@ -51,7 +51,10 @@ namespace BuildMagicEditor
                 if (scheme == null)
                     return;
 
-                var preBuildTask = BuildTaskBuilderUtility.CreateBuildTasks<IPreBuildContext>(scheme.PreBuildConfigurations);
+                var preBuildTask = BuildTaskBuilderUtility.CreateBuildTasks<IPreBuildContext>(
+                    BuildSchemeUtility.EnumerateComposedConfigurations<IPostBuildContext>(scheme,
+                        BuildSchemeLoader.LoadAll<BuildScheme>()));
+
                 BuildPipeline.PreBuild(preBuildTask);
             };
         }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildSchemeUtility.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildSchemeUtility.cs
@@ -36,7 +36,11 @@ namespace BuildMagicEditor
                     yield return ancestor;
             }
 
-            return LoadBaseSchemesCore(scheme, allSchemes, new HashSet<BuildScheme>());
+            // If we return IEnumerable directly, it may cause "circular inheritance detected" when we evaluate it multiple times because the HashSet instance is shared.
+            foreach (var item in LoadBaseSchemesCore(scheme, allSchemes, new HashSet<BuildScheme>()))
+            {
+                yield return item;
+            }
         }
 
         public static IEnumerable<IBuildConfiguration> EnumerateComposedConfigurations<TContext>(


### PR DESCRIPTION
This PR fixes the issue that derived configurations and "Just before the build" configurations may be ignored in some situations.