### PR TITLE
Fix ObjectDisposedException on configuration unbinding

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationEntryView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationEntryView.cs
@@ -25,6 +25,14 @@ namespace BuildMagic.Window.Editor.Elements
             label = configuration?.GetDisplayName() ?? configuration?.PropertyName ?? "Missing";
         }
 
+        public void Unbind()
+        {
+            Type = ConfigurationType.None;
+            Index = -1;
+            Configuration = null;
+            BindingExtensions.Unbind(this);
+        }
+
         public void CollectProjectSetting()
         {
             Assert.IsTrue(Configuration is IProjectSettingApplier);

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs
@@ -184,7 +184,6 @@ namespace BuildMagic.Window.Editor.Elements
         {
             var entry = element as ConfigurationEntryView;
             Assert.IsNotNull(entry);
-            entry.Bind(ConfigurationType.None, -1, null);
             entry.Unbind();
         }
 


### PR DESCRIPTION
Fixed `ObjectDisposedException` thrown by `ConfigurationEntryView.Bind()`.
This exception occurs due to making changes to `PropertyField.label` after previously bound `SerializedProperty` is disposed.
This is caused by #32 .

```
ObjectDisposedException: SerializedProperty _selected._self._preBuildConfigurations.Array.data[0]._value has disappeared!
  at (wrapper managed-to-native) UnityEditor.SerializedProperty.SyncSerializedObjectVersion(UnityEditor.SerializedProperty)
...
  at UnityEditor.UIElements.PropertyField.set_label (System.String value) [0x0001a] in /Users/bokken/build/output/unity/unity/Editor/Mono/UIElements/Controls/PropertyField.cs:80 
  at BuildMagic.Window.Editor.Elements.ConfigurationEntryView.Bind (BuildMagic.Window.Editor.ConfigurationType type, System.Int32 index, BuildMagicEditor.IBuildConfiguration configuration) [0x00015] in ./Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationEntryView.cs:25 
  at BuildMagic.Window.Editor.Elements.ConfigurationListView.UnbindConfiguration (UnityEngine.UIElements.VisualElement element) [0x0000c] in ./Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs:187 
  at BuildMagic.Window.Editor.Elements.ConfigurationListView+<>c.<Bind>b__12_2 (UnityEngine.UIElements.VisualElement e, System.Int32 _) [0x00000] in ./Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs:85 
...
```
