### PR TITLE
Abstraction of build scheme context menu actions

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowPresenter.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowPresenter.cs
@@ -197,7 +197,6 @@ namespace BuildMagic.Window.Editor
                 return new BuildSchemeContextualActions(getSchemeName, this);
             }
 
-
             private class BuildSchemeContextualActions : IBuildSchemeContextualActions
             {
                 private readonly Func<string> _getSchemeName;
@@ -245,6 +244,7 @@ namespace BuildMagic.Window.Editor
                     _factory.UnsetPrimaryRequested?.Invoke(_getSchemeName());
                 }
 
+                public bool IsActive => !string.IsNullOrEmpty(_getSchemeName());
                 public bool IsPrimary => _factory.IsPrimary(_getSchemeName());
             }
         }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowPresenter.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowPresenter.cs
@@ -51,9 +51,12 @@ namespace BuildMagic.Window.Editor
             contextualOptionsFactory.BuildRequested += Build;
             contextualOptionsFactory.SetAsPrimaryRequested += SetAsPrimary;
             contextualOptionsFactory.UnsetPrimaryRequested += UnsetPrimary;
+            contextualOptionsFactory.IsPrimary = schemeName =>
+                BuildMagicSettings.instance.PrimaryBuildScheme == schemeName;
 
             _view.LeftPaneView.ContextualActionsFactory = contextualOptionsFactory;
-            _view.LeftPaneView.ContextualActionsForSelectedScheme = contextualOptionsFactory.Create(() => _model.SelectedBuildSchemeName);
+            _view.LeftPaneView.ContextualActionsForSelectedScheme =
+                contextualOptionsFactory.Create(() => _model.SelectedBuildSchemeName);
             _view.LeftPaneView.OnSelectionChanged += OnSelectionChanged;
             _view.LeftPaneView.SaveRequested += Save;
             _view.LeftPaneView.NewBuildSchemeRequested += NewScheme;
@@ -187,6 +190,7 @@ namespace BuildMagic.Window.Editor
             public event Action<string> BuildRequested;
             public event Action<string> SetAsPrimaryRequested;
             public event Action<string> UnsetPrimaryRequested;
+            public Func<string, bool> IsPrimary { private get; set; }
 
             public IBuildSchemeContextualActions Create(Func<string> getSchemeName)
             {
@@ -241,7 +245,7 @@ namespace BuildMagic.Window.Editor
                     _factory.UnsetPrimaryRequested?.Invoke(_getSchemeName());
                 }
 
-                public bool IsPrimary => _getSchemeName() == BuildMagicSettings.instance.PrimaryBuildScheme;
+                public bool IsPrimary => _factory.IsPrimary(_getSchemeName());
             }
         }
     }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowPresenter.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowPresenter.cs
@@ -43,14 +43,20 @@ namespace BuildMagic.Window.Editor
         {
             Undo.undoRedoEvent += OnUndoRedo;
 
-            _view.LeftPaneView.CopyCreateRequested += CopyCreate;
-            _view.LeftPaneView.InheritCreateRequested += InheritCreate;
-            _view.LeftPaneView.RemoveRequested += Remove;
-            _view.LeftPaneView.PreBuildRequested += PreBuild;
-            _view.LeftPaneView.PreBuildRequestedByName += PreBuildByName;
-            _view.LeftPaneView.BuildRequested += Build;
+            var contextualOptionsFactory = new BuildSchemeContextualActionsFactory();
+            contextualOptionsFactory.CopyCreateRequested += CopyCreate;
+            contextualOptionsFactory.InheritCreateRequested += InheritCreate;
+            contextualOptionsFactory.RemoveRequested += Remove;
+            contextualOptionsFactory.PreBuildRequested += PreBuild;
+            contextualOptionsFactory.BuildRequested += Build;
+            contextualOptionsFactory.SetAsPrimaryRequested += SetAsPrimary;
+            contextualOptionsFactory.UnsetPrimaryRequested += UnsetPrimary;
+
+            _view.LeftPaneView.ContextualActionsFactory = contextualOptionsFactory;
+            _view.LeftPaneView.ContextualActionsForSelectedScheme = contextualOptionsFactory.Create(() => _model.SelectedBuildSchemeName);
             _view.LeftPaneView.OnSelectionChanged += OnSelectionChanged;
             _view.LeftPaneView.SaveRequested += Save;
+            _view.LeftPaneView.NewBuildSchemeRequested += NewScheme;
 
             _view.RightPaneView.AddRequested += OnAddRequested;
             _view.RightPaneView.RemoveRequested += RemoveConfiguration;
@@ -63,12 +69,7 @@ namespace BuildMagic.Window.Editor
 
             _view.LeftPaneView.SaveRequested -= Save;
             _view.LeftPaneView.OnSelectionChanged -= OnSelectionChanged;
-            _view.LeftPaneView.BuildRequested -= Build;
-            _view.LeftPaneView.PreBuildRequestedByName -= PreBuildByName;
-            _view.LeftPaneView.PreBuildRequested -= PreBuild;
-            _view.LeftPaneView.RemoveRequested -= Remove;
-            _view.LeftPaneView.InheritCreateRequested -= InheritCreate;
-            _view.LeftPaneView.CopyCreateRequested -= CopyCreate;
+            _view.LeftPaneView.NewBuildSchemeRequested -= NewScheme;
 
             Undo.undoRedoEvent -= OnUndoRedo;
         }
@@ -94,6 +95,11 @@ namespace BuildMagic.Window.Editor
 
         #region EventHandlers
 
+        private void NewScheme()
+        {
+            CopyCreate(string.Empty);
+        }
+
         private void CopyCreate(string copyFromName)
         {
             var baseSchemeName = _model.GetBaseSchemeName(copyFromName);
@@ -101,7 +107,7 @@ namespace BuildMagic.Window.Editor
                 _model.RootSchemeNames, _model.Create);
             CreateSchemeModalWindow.OpenModal(context);
         }
-        
+
         private void InheritCreate(string baseSchemeName)
         {
             var context = new CreateSchemeModalWindow.Context("", baseSchemeName, _model.SchemeNamesWithTemplate,
@@ -114,29 +120,37 @@ namespace BuildMagic.Window.Editor
             _model.Remove(targetSettingName);
         }
 
-        private void PreBuild()
+        private void PreBuild(string targetSchemeName)
         {
-            _model.PreBuild();
-        }
-        
-        private void PreBuildByName(string targetSettingName)
-        {
-            _model.PreBuildByName(targetSettingName);
+            _model.PreBuild(targetSchemeName);
         }
 
-        private void Build()
+        private void Build(string targetSchemeName)
         {
             var buildPath = EditorUtility.SaveFilePanel("Build Application Path", "", "", "");
             if (string.IsNullOrWhiteSpace(buildPath))
                 return;
-            _model.Build(buildPath);
+            _model.Build(targetSchemeName, buildPath);
+        }
+
+        private void SetAsPrimary(string targetSchemeName)
+        {
+            BuildMagicSettings.instance.PrimaryBuildScheme = targetSchemeName;
+        }
+
+        private void UnsetPrimary(string targetSchemeName)
+        {
+            if (BuildMagicSettings.instance.PrimaryBuildScheme != targetSchemeName)
+                return;
+
+            BuildMagicSettings.instance.PrimaryBuildScheme = string.Empty;
         }
 
         private void OnSelectionChanged(int index)
         {
             _model.Select(index);
         }
-        
+
         private void OnAddRequested(Rect rect)
         {
             var existConfigurations = _model.GetConfigurationTypes();
@@ -163,5 +177,72 @@ namespace BuildMagic.Window.Editor
         }
 
         #endregion
+
+        private class BuildSchemeContextualActionsFactory : IBuildSchemeContextualActionsFactory
+        {
+            public event Action<string> CopyCreateRequested;
+            public event Action<string> InheritCreateRequested;
+            public event Action<string> RemoveRequested;
+            public event Action<string> PreBuildRequested;
+            public event Action<string> BuildRequested;
+            public event Action<string> SetAsPrimaryRequested;
+            public event Action<string> UnsetPrimaryRequested;
+
+            public IBuildSchemeContextualActions Create(Func<string> getSchemeName)
+            {
+                return new BuildSchemeContextualActions(getSchemeName, this);
+            }
+
+
+            private class BuildSchemeContextualActions : IBuildSchemeContextualActions
+            {
+                private readonly Func<string> _getSchemeName;
+                private readonly BuildSchemeContextualActionsFactory _factory;
+
+                public BuildSchemeContextualActions(Func<string> getSchemeName,
+                    BuildSchemeContextualActionsFactory factory)
+                {
+                    _getSchemeName = getSchemeName;
+                    _factory = factory;
+                }
+
+                public void CopyCreateRequested()
+                {
+                    _factory.CopyCreateRequested?.Invoke(_getSchemeName());
+                }
+
+                public void InheritCreateRequested()
+                {
+                    _factory.InheritCreateRequested?.Invoke(_getSchemeName());
+                }
+
+                public void RemoveRequested()
+                {
+                    _factory.RemoveRequested?.Invoke(_getSchemeName());
+                }
+
+                public void PreBuildRequested()
+                {
+                    _factory.PreBuildRequested?.Invoke(_getSchemeName());
+                }
+
+                public void BuildRequested()
+                {
+                    _factory.BuildRequested?.Invoke(_getSchemeName());
+                }
+
+                public void SetAsPrimaryRequested()
+                {
+                    _factory.SetAsPrimaryRequested?.Invoke(_getSchemeName());
+                }
+
+                public void UnsetPrimaryRequested()
+                {
+                    _factory.UnsetPrimaryRequested?.Invoke(_getSchemeName());
+                }
+
+                public bool IsPrimary => _getSchemeName() == BuildMagicSettings.instance.PrimaryBuildScheme;
+            }
+        }
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ILeftPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ILeftPaneView.cs
@@ -8,15 +8,13 @@ namespace BuildMagic.Window.Editor.Elements
 {
     internal interface ILeftPaneView
     {
-        event Action<string> CopyCreateRequested;
-        event Action<string> InheritCreateRequested;
-        event Action<string> RemoveRequested;
-        event Action PreBuildRequested;
-        event Action<string> PreBuildRequestedByName;
-        event Action BuildRequested;
+        public IBuildSchemeContextualActionsFactory ContextualActionsFactory { set; }
+
+        public IBuildSchemeContextualActions ContextualActionsForSelectedScheme { set; }
 
         event Action<int> OnSelectionChanged;
         
         event Action SaveRequested;
+        event Action NewBuildSchemeRequested;
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneListEntryView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneListEntryView.cs
@@ -24,29 +24,26 @@ namespace BuildMagic.Window.Editor.Elements
             _label = this.Q<Label>("name-label");
             Assert.IsNotNull(_label);
             _label.bindingPath = "_name";
-            
+
             _autoMark = this.Q<VisualElement>("auto-mark");
             Assert.IsNotNull(_autoMark);
         }
 
         public string Value => _label.text;
-        public bool Inheritable { get; private set; }
 
         public void CustomBind(SerializedProperty property)
         {
             using var scope = new DebugLogDisabledScope();
             this.BindProperty(property);
-            Inheritable = property.FindPropertyRelative("_baseSchemeName").stringValue == string.Empty;
             BuildMagicSettings.instance.PrimaryBuildSchemeChanged += OnAutoPreBuildTargetChanged;
         }
-        
+
         public void CustomUnbind()
         {
             this.Unbind();
-            Inheritable = false;
             BuildMagicSettings.instance.PrimaryBuildSchemeChanged -= OnAutoPreBuildTargetChanged;
         }
-        
+
         private void OnAutoPreBuildTargetChanged(string target)
         {
             _autoMark.style.visibility = Value == target ? Visibility.Visible : Visibility.Hidden;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
@@ -29,7 +29,7 @@ namespace BuildMagic.Window.Editor.Elements
                 item.AddManipulator(new ContextualMenuManipulator(ev =>
                 {
                     var actions = ContextualActionsFactory?.Create(() => item.Value);
-                    IBuildSchemeContextualActions.PopulateMenu(() => actions, "", ev.menu);
+                    IBuildSchemeContextualActions.PopulateMenu(() => actions, ev.menu);
                 }));
                 return item;
             };

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
@@ -22,23 +22,14 @@ namespace BuildMagic.Window.Editor.Elements
         public LeftPaneTreeView()
         {
             hierarchy.Add(_currentTracker = new VisualElement());
+
             makeItem = () =>
             {
                 var item = new LeftPaneListEntryView();
                 item.AddManipulator(new ContextualMenuManipulator(ev =>
                 {
-                    ev.menu.AppendAction("Create a build scheme copy from this",
-                        _ => CopyCreateRequested?.Invoke(item.Value));
-                    ev.menu.AppendAction("Create a build scheme inherit this",
-                        _ => InheritCreateRequested?.Invoke(item.Value),
-                        item.Inheritable ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
-                    ev.menu.AppendAction("Remove this", _ => RemoveRequested?.Invoke(item.Value));
-                    ev.menu.AppendAction("Switch to this", _ => PreBuildRequestedByName?.Invoke(item.Value));
-                    ev.menu.AppendAction("Set as primary build scheme",
-                        _ => BuildMagicSettings.instance.PrimaryBuildScheme = item.Value,
-                        _ => item.Value == BuildMagicSettings.instance.PrimaryBuildScheme
-                            ? DropdownMenuAction.Status.Disabled
-                            : DropdownMenuAction.Status.Normal);
+                    var actions = ContextualActionsFactory?.Create(() => item.Value);
+                    IBuildSchemeContextualActions.PopulateMenu(() => actions, "", ev.menu);
                 }));
                 return item;
             };
@@ -74,10 +65,8 @@ namespace BuildMagic.Window.Editor.Elements
             };
         }
 
-        public event Action<string> CopyCreateRequested;
-        public event Action<string> InheritCreateRequested;
-        public event Action<string> RemoveRequested;
-        public event Action<string> PreBuildRequestedByName;
+        public IBuildSchemeContextualActionsFactory ContextualActionsFactory { private get; set; }
+
         public event Action<int> OnSelectionChanged;
 
         public void SelectIndex(int index)

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
@@ -16,6 +16,7 @@ namespace BuildMagic.Window.Editor.Elements
     {
         private readonly VisualTreeAsset _listEntryTemplate;
         private readonly LeftPaneTreeView _treeView;
+        private IBuildSchemeContextualActionsFactory _contextualActionsFactory;
 
         public LeftPaneView()
         {
@@ -30,19 +31,12 @@ namespace BuildMagic.Window.Editor.Elements
             var toolbarMenu = this.Q<ToolbarMenu>();
             Assert.IsNotNull(toolbarMenu);
 
-            toolbarMenu.menu.AppendAction("Create a build scheme", _ => CopyCreateRequested?.Invoke(string.Empty));
+            toolbarMenu.menu.AppendAction("New Build Scheme...", _ => NewBuildSchemeRequested?.Invoke());
+            IBuildSchemeContextualActions.PopulateMenu(() => ContextualActionsForSelectedScheme,
+                "Selected Build Scheme/", toolbarMenu.menu);
             toolbarMenu.menu.AppendSeparator();
-            toolbarMenu.menu.AppendAction("Remove the selected build scheme",
-                _ => RemoveRequested?.Invoke(string.Empty),
-                OnMenuActionStatus);
-            toolbarMenu.menu.AppendAction("Run Pre-build phase of the selected build scheme",
-                _ => PreBuildRequested?.Invoke(),
-                OnMenuActionStatus);
-            toolbarMenu.menu.AppendAction("Build with the selected scheme", _ => BuildRequested?.Invoke(),
-                OnMenuActionStatus);
-            toolbarMenu.menu.AppendSeparator();
-            toolbarMenu.menu.AppendAction("Open diff window", _ => DiffWindow.Open());
-            toolbarMenu.menu.AppendAction("Enable \"Just before the build\" phase (advanced)", _ =>
+            toolbarMenu.menu.AppendAction("Show Diff...", _ => DiffWindow.Open());
+            toolbarMenu.menu.AppendAction("Enable \"Just before the build\" Phase (advanced)", _ =>
                 {
                     var v = UserSettings.EnableInternalPrepareEditor;
                     v.Value = !v.Value;
@@ -53,20 +47,22 @@ namespace BuildMagic.Window.Editor.Elements
 
             _treeView = this.Q<LeftPaneTreeView>();
             Assert.IsNotNull(_treeView);
-            _treeView.CopyCreateRequested += value => CopyCreateRequested(value);
-            _treeView.InheritCreateRequested += value => InheritCreateRequested(value);
-            _treeView.RemoveRequested += value => RemoveRequested(value);
-            _treeView.PreBuildRequestedByName += value => PreBuildRequestedByName(value);
             _treeView.OnSelectionChanged += index => OnSelectionChanged(index);
         }
 
-        public event Action<string> CopyCreateRequested;
-        public event Action<string> InheritCreateRequested;
-        public event Action<string> RemoveRequested;
-        public event Action<string> PreBuildRequestedByName;
+        public IBuildSchemeContextualActionsFactory ContextualActionsFactory
+        {
+            set
+            {
+                _contextualActionsFactory = value;
+                _treeView.ContextualActionsFactory = value;
+            }
+        }
+
+        public IBuildSchemeContextualActions ContextualActionsForSelectedScheme { private get; set; }
+
+        public event Action NewBuildSchemeRequested;
         public event Action<int> OnSelectionChanged;
-        public event Action PreBuildRequested;
-        public event Action BuildRequested;
         public event Action SaveRequested;
 
         public void OnBoundSchemeListChanged(SerializedProperty schemesProp)

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
@@ -32,8 +32,8 @@ namespace BuildMagic.Window.Editor.Elements
             Assert.IsNotNull(toolbarMenu);
 
             toolbarMenu.menu.AppendAction("New Build Scheme...", _ => NewBuildSchemeRequested?.Invoke());
-            IBuildSchemeContextualActions.PopulateMenu(() => ContextualActionsForSelectedScheme,
-                "Selected Build Scheme/", toolbarMenu.menu);
+            IBuildSchemeContextualActions.PopulateMenu(() => ContextualActionsForSelectedScheme, toolbarMenu.menu,
+                "Selected Build Scheme");
             toolbarMenu.menu.AppendSeparator();
             toolbarMenu.menu.AppendAction("Show Diff...", _ => DiffWindow.Open());
             toolbarMenu.menu.AppendAction("Enable \"Just before the build\" Phase (advanced)", _ =>

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActions.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActions.cs
@@ -20,26 +20,27 @@ namespace BuildMagic.Window.Editor
         public void SetAsPrimaryRequested();
         public void UnsetPrimaryRequested();
 
-        public static void PopulateMenu(Func<IBuildSchemeContextualActions> getOptions, string actionNamePrefix,
-            DropdownMenu menu)
+        public static void PopulateMenu(Func<IBuildSchemeContextualActions> getOptions, DropdownMenu menu,
+            string subMenuPath = null)
         {
             Func<DropdownMenuAction, DropdownMenuAction.Status> getStatus = _ =>
                 getOptions().IsActive ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled;
-            menu.AppendAction($"{actionNamePrefix}Apply Pre-build Now", _ => getOptions().PreBuildRequested(),
+            var prefix = string.IsNullOrEmpty(subMenuPath) ? string.Empty : $"{subMenuPath}/";
+            menu.AppendAction($"{prefix}Apply Pre-build Now", _ => getOptions().PreBuildRequested(),
                 getStatus);
-            menu.AppendAction($"{actionNamePrefix}Build Player Now...", _ => getOptions().BuildRequested(), getStatus);
-            menu.AppendSeparator(actionNamePrefix);
-            menu.AppendAction($"{actionNamePrefix}Copy...", _ => getOptions().CopyCreateRequested(), getStatus);
-            menu.AppendAction($"{actionNamePrefix}Inherit...", _ => getOptions().InheritCreateRequested(), getStatus);
-            menu.AppendAction($"{actionNamePrefix}Remove", _ => getOptions().RemoveRequested(), getStatus);
-            menu.AppendAction($"{actionNamePrefix}Unset Primary", _ => getOptions().UnsetPrimaryRequested(),
+            menu.AppendAction($"{prefix}Build Player Now...", _ => getOptions().BuildRequested(), getStatus);
+            menu.AppendSeparator(prefix);
+            menu.AppendAction($"{prefix}Copy...", _ => getOptions().CopyCreateRequested(), getStatus);
+            menu.AppendAction($"{prefix}Inherit...", _ => getOptions().InheritCreateRequested(), getStatus);
+            menu.AppendAction($"{prefix}Remove", _ => getOptions().RemoveRequested(), getStatus);
+            menu.AppendAction($"{prefix}Unset Primary", _ => getOptions().UnsetPrimaryRequested(),
                 _ => getOptions() switch
                 {
                     { IsPrimary: false } => DropdownMenuAction.Status.Hidden,
                     { IsActive: false } => DropdownMenuAction.Status.Disabled,
                     _ => DropdownMenuAction.Status.Normal
                 });
-            menu.AppendAction($"{actionNamePrefix}Set as Primary", _ => getOptions().SetAsPrimaryRequested(),
+            menu.AppendAction($"{prefix}Set as Primary", _ => getOptions().SetAsPrimaryRequested(),
                 _ => getOptions() switch
                 {
                     { IsPrimary: true } => DropdownMenuAction.Status.Hidden,

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActions.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActions.cs
@@ -1,0 +1,37 @@
+// --------------------------------------------------------------
+// Copyright 2025 CyberAgent, Inc.
+// --------------------------------------------------------------
+
+using System;
+using UnityEngine.UIElements;
+
+namespace BuildMagic.Window.Editor
+{
+    internal interface IBuildSchemeContextualActions
+    {
+        public bool IsPrimary { get; }
+
+        public void CopyCreateRequested();
+        public void InheritCreateRequested();
+        public void RemoveRequested();
+        public void PreBuildRequested();
+        public void BuildRequested();
+        public void SetAsPrimaryRequested();
+        public void UnsetPrimaryRequested();
+
+        public static void PopulateMenu(Func<IBuildSchemeContextualActions> getOptions, string actionNamePrefix,
+            DropdownMenu menu)
+        {
+            menu.AppendAction($"{actionNamePrefix}Apply Pre-build Now", _ => getOptions().PreBuildRequested());
+            menu.AppendAction($"{actionNamePrefix}Build Player Now...", _ => getOptions().BuildRequested());
+            menu.AppendSeparator(actionNamePrefix);
+            menu.AppendAction($"{actionNamePrefix}Copy...", _ => getOptions().CopyCreateRequested());
+            menu.AppendAction($"{actionNamePrefix}Inherit...", _ => getOptions().InheritCreateRequested());
+            menu.AppendAction($"{actionNamePrefix}Remove", _ => getOptions().RemoveRequested());
+            menu.AppendAction($"{actionNamePrefix}Unset Primary", _ => getOptions().UnsetPrimaryRequested(),
+                _ => getOptions().IsPrimary ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Hidden);
+            menu.AppendAction($"{actionNamePrefix}Set as Primary", _ => getOptions().SetAsPrimaryRequested(),
+                _ => getOptions().IsPrimary ? DropdownMenuAction.Status.Hidden : DropdownMenuAction.Status.Normal);
+        }
+    }
+}

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActions.cs.meta
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d8f0233004ee4c4abbe801d635f3bf6b
+timeCreated: 1747633709

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActionsFactory.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActionsFactory.cs
@@ -1,0 +1,13 @@
+// --------------------------------------------------------------
+// Copyright 2025 CyberAgent, Inc.
+// --------------------------------------------------------------
+
+using System;
+
+namespace BuildMagic.Window.Editor
+{
+    internal interface IBuildSchemeContextualActionsFactory
+    {
+        public IBuildSchemeContextualActions Create(Func<string> getSchemeName);
+    }
+}

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActionsFactory.cs.meta
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActionsFactory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 730fbd2d4bec40dab70ec059292148f3
+timeCreated: 1747644371


### PR DESCRIPTION
This PR makes BuildMagic window to provide same options for both context menu of build schemes and "Selected Build Scheme" in toolbar menu. This is achieved through `IBuildSchemeContextualActions` and `IBuildSchemeContextualActionsFactory` abstractions.

<img width="442" alt="image" src="https://github.com/user-attachments/assets/4f0a0bed-c73f-4205-b5d8-61b4be55999f" />
<img width="515" alt="image" src="https://github.com/user-attachments/assets/d87e4c39-d98a-4ecf-9ca9-fc92d183e5b3" />
