### PR TITLE
Copy and paste configurations

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowModel.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowModel.cs
@@ -216,8 +216,11 @@ namespace BuildMagic.Window.Editor
                 _selectedIndex.SetValueAndNotify(_selectedIndex.Value);
             }
         }
+        
+        public void AddConfiguration(ConfigurationType configurationType, Type type) 
+            => AddConfiguration(configurationType, type, null);
 
-        public void AddConfiguration(ConfigurationType configurationType, Type type)
+        public void AddConfiguration(ConfigurationType configurationType, Type type, string json)
         {
             Assert.IsNotNull(_selected, "No selected scheme");
             Assert.IsTrue(configurationType != ConfigurationType.None, "Invalid configuration type");
@@ -227,6 +230,8 @@ namespace BuildMagic.Window.Editor
 
             var configuration = (IBuildConfiguration)Activator.CreateInstance(type);
             Assert.IsNotNull(configuration, "Failed to create configuration");
+            if (json != null)
+                JsonUtility.FromJsonOverwrite(json, configuration);
 
             switch (configurationType)
             {

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowPresenter.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindowPresenter.cs
@@ -5,6 +5,7 @@
 using System;
 using BuildMagic.Window.Editor.Foundation.TinyRx;
 using BuildMagic.Window.Editor.SubWindows;
+using BuildMagic.Window.Editor.Utilities;
 using BuildMagicEditor;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
@@ -61,12 +62,15 @@ namespace BuildMagic.Window.Editor
             _view.LeftPaneView.SaveRequested += Save;
             _view.LeftPaneView.NewBuildSchemeRequested += NewScheme;
 
+            _view.RightPaneView.CanPaste = CanPaste;
             _view.RightPaneView.AddRequested += OnAddRequested;
             _view.RightPaneView.RemoveRequested += RemoveConfiguration;
+            _view.RightPaneView.PasteRequested += PasteConfiguration;
         }
 
         private void CleanupViewEventHandlers()
         {
+            _view.RightPaneView.PasteRequested -= PasteConfiguration;
             _view.RightPaneView.RemoveRequested -= RemoveConfiguration;
             _view.RightPaneView.AddRequested -= OnAddRequested;
 
@@ -164,6 +168,24 @@ namespace BuildMagic.Window.Editor
         private void RemoveConfiguration(ConfigurationType type, int index, IBuildConfiguration configuration)
         {
             _model.RemoveConfiguration(type, index, configuration);
+        }
+
+        private bool CanPaste(ConfigurationType type)
+        {
+            if (ObjectCopyBuffer.Type == null || ObjectCopyBuffer.Json == null)
+                return false;
+
+            var configurationType = ObjectCopyBuffer.Type;
+            var existConfigurations = _model.GetConfigurationTypes();
+            return !existConfigurations.Contains(configurationType);
+        }
+
+        private void PasteConfiguration(ConfigurationType type)
+        {
+            if (CanPaste(type) == false)
+                EditorUtility.DisplayDialog("Paste Configuration", "Cannot Paste Configuration", "OK");
+            
+            _model.AddConfiguration(type, ObjectCopyBuffer.Type, ObjectCopyBuffer.Json);
         }
 
         private void Save()

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/IRightPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/IRightPaneView.cs
@@ -12,5 +12,8 @@ namespace BuildMagic.Window.Editor.Elements
     {
         event Action<Rect> AddRequested;
         event Action<ConfigurationType, int, IBuildConfiguration> RemoveRequested;
+        event Action<ConfigurationType> PasteRequested;
+        
+        Func<ConfigurationType, bool> CanPaste { set; }
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
@@ -64,6 +64,8 @@ namespace BuildMagic.Window.Editor.Elements
 
         public event Action<Rect> AddRequested;
         public event Action<ConfigurationType, int, IBuildConfiguration> RemoveRequested;
+        public event Action<ConfigurationType> PasteRequested;
+        public Func<ConfigurationType, bool> CanPaste { get; set; }
 
         public void SetSelected(bool selected)
         {
@@ -81,6 +83,8 @@ namespace BuildMagic.Window.Editor.Elements
             {
                 configurationListView.Bind(selectedSchemeProp,
                     (type, index, configuration) => RemoveRequested?.Invoke(type, index, configuration),
+                    (type) => CanPaste?.Invoke(type) ?? false,
+                    (type) => PasteRequested?.Invoke(type),
                     out var hasAny);
                 if (configurationListView.Type == ConfigurationType.InternalPrepare)
                     hasAnyInternalPrepareConfigurations = hasAny;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/ObjectCopyBuffer.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/ObjectCopyBuffer.cs
@@ -1,0 +1,35 @@
+// --------------------------------------------------------------
+// Copyright 2025 CyberAgent, Inc.
+// --------------------------------------------------------------
+
+using System;
+using UnityEngine;
+
+namespace BuildMagic.Window.Editor.Utilities
+{
+    /// <summary>
+    ///     Buffer to copy and paste serializable object data.
+    /// </summary>
+    public static class ObjectCopyBuffer
+    {
+        /// <summary>
+        ///     Serialized data of the registered object.
+        /// </summary>
+        public static string Json { get; private set; }
+
+        /// <summary>
+        ///     Type of the registered object.
+        /// </summary>
+        public static Type Type { get; private set; }
+
+        /// <summary>
+        ///     Register the object data.
+        /// </summary>
+        /// <param name="target"></param>
+        public static void Register(object target)
+        {
+            Type = target.GetType();
+            Json = JsonUtility.ToJson(target);
+        }
+    }
+}

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/ObjectCopyBuffer.cs.meta
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/ObjectCopyBuffer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 688af59bf2c34b788e92792d92a661af
+timeCreated: 1747896388


### PR DESCRIPTION
- Copy the configuration values to clipboard as a json
- Copy the configuration
  - Paired with “Paste the configuration.”
  - Keep a copy of configuration internally
- Paste the configuration
  - For operation on a configuration, overwrite the value. If the type is different, it cannot be performed.
  - For operation on a list, add a configuration. If the type already exists in the list, it cannot be performed.