### PR TITLE
Add iOS URL schemes configuration to built-in build tasks

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuiltIn/AddiOSUrlSchemesTask.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuiltIn/AddiOSUrlSchemesTask.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.iOS.Xcode;
+
+namespace BuildMagicEditor.BuiltIn
+{
+    /// <summary>
+    ///     This task adds custom URL schemes to the iOS Info.plist file during the build process.
+    ///     URL schemes allow the app to be opened from other applications or web browsers using custom URLs (e.g.,
+    ///     "myapp://path").
+    ///     This is commonly used for deep linking, OAuth callbacks, inter-app communication, and handling custom protocol
+    ///     redirects.
+    ///     The task configures CFBundleURLTypes in Info.plist with the specified URL name, type role, and URL schemes.
+    /// </summary>
+    [GenerateBuildTaskAccessories("Add iOS URL Schemes",
+        PropertyName = "BuildMagicEditor.BuiltIn.AddiOSUrlSchemesTask.urlSchemes")]
+    public sealed class AddiOSUrlSchemesTask : BuildTaskBase<IPostBuildContext>
+    {
+        /// <summary>
+        ///     CFBundleTypeRole
+        ///     <see cref="https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleurltypes/cfbundletyperole" />
+        /// </summary>
+        public enum TypeRole
+        {
+            None,
+            Editor,
+            Viewer,
+            Shell,
+            QLGenerator
+        }
+
+        private readonly TypeRole _typeRole;
+        private readonly string _urlIconFile;
+        private readonly string _urlName;
+        private readonly string[] _urlSchemes;
+
+        public AddiOSUrlSchemesTask(TypeRole typeRole, string urlIconFile, string urlName, string[] urlSchemes)
+        {
+            _typeRole = typeRole;
+            _urlIconFile = urlIconFile;
+            _urlName = urlName;
+            _urlSchemes = urlSchemes;
+        }
+
+        public override void Run(IPostBuildContext context)
+        {
+            if (context.ActiveBuildTarget != BuildTarget.iOS) return;
+
+#if UNITY_IOS
+            RunInternal(context);
+#endif
+        }
+
+#if UNITY_IOS
+        private void RunInternal(IPostBuildContext context)
+        {
+            var projectRootPath = context.BuildReport.summary.outputPath;
+            var infoPlistPath = Path.Combine(projectRootPath, "Info.plist");
+            if (!File.Exists(infoPlistPath)) return;
+
+            var plist = new PlistDocument();
+            plist.ReadFromFile(infoPlistPath);
+
+            var root = plist.root;
+            var bundleUrlTypes = root.CreateArray("CFBundleURLTypes");
+            var dict = bundleUrlTypes.AddDict();
+
+            dict.SetString("CFBundleTypeRole", _typeRole.ToString());
+            if (!string.IsNullOrEmpty(_urlIconFile))
+                dict.SetString("CFBundleURLIconFile", Path.GetFileName(_urlIconFile));
+
+            dict.SetString("CFBundleURLName", _urlName);
+            var urlSchemesArray = ForceCreateElementArray(dict, "CFBundleURLSchemes");
+            foreach (var urlScheme in _urlSchemes.Distinct())
+            {
+                if (string.IsNullOrEmpty(urlScheme)) continue;
+
+                urlSchemesArray.AddString(urlScheme);
+            }
+
+            plist.WriteToFile(infoPlistPath);
+        }
+
+        /// <summary>
+        ///     Creates a new PlistElementArray with the specified key in the given PlistElementDict.
+        ///     If the key already exists, it will be removed before creating the new array.
+        /// </summary>
+        private PlistElementArray ForceCreateElementArray(PlistElementDict element, string key)
+        {
+            if (element.values.ContainsKey(key))
+                if (!element.values.Remove(key))
+                    throw new InvalidOperationException("Failed to remove existing key: " + key);
+
+            return element.CreateArray(key);
+        }
+#endif
+    }
+}

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuiltIn/AddiOSUrlSchemesTask.cs.meta
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuiltIn/AddiOSUrlSchemesTask.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74812a6b693dd499da84dee54e4edb14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

This PR adds a new built-in build task `AddiOSUrlSchemesTask`, providing automatic iOS URL schemes configuration during the build process.

## Usage & Configuration

The task can be configured through the BuildMagicWindows by adding "Add iOS URL Schemes" task:

![Screenshot 2025-06-01 at 22 56 30](https://github.com/user-attachments/assets/be10103d-0fae-4c05-a959-a9d0880876f7)

After building to iOS, the URL schemes are automatically configured in the Xcode project:

![Screenshot 2025-06-01 at 22 57 20](https://github.com/user-attachments/assets/84071d44-305f-4c99-a68f-d7a0d82c43d4)
