### PR TITLE
Fix compilation errors in AddiOSUrlSchemesTask.

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuiltIn/AddiOSUrlSchemesTask.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuiltIn/AddiOSUrlSchemesTask.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.Linq;
 using UnityEditor;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif
 
 namespace BuildMagicEditor.BuiltIn
 {


### PR DESCRIPTION
Fixed compilation errors in AddiOSUrlSchemesTask when platform settings are set to non-iOS platforms