### PR TITLE
Fixed object reference is not persisted

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildSchemeSerializer.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildSchemeSerializer.cs
@@ -2,7 +2,8 @@
 // Copyright 2024 CyberAgent, Inc.
 // --------------------------------------------------------------
 
-using UnityEngine;
+using System;
+using UnityEditor;
 
 namespace BuildMagicEditor
 {
@@ -10,10 +11,14 @@ namespace BuildMagicEditor
     {
         public static string Serialize(IBuildScheme schemes)
         {
-            return JsonUtility.ToJson(schemes, true);
+            return EditorJsonUtility.ToJson(schemes, true);
         }
 
         public static T Deserialize<T>(string json) where T : IBuildScheme
-            => JsonUtility.FromJson<T>(json);
+        {
+            var obj = Activator.CreateInstance(typeof(T));
+            EditorJsonUtility.FromJsonOverwrite(json, obj);
+            return (T)obj;
+        }
     }
 }


### PR DESCRIPTION
Changed `BuildSchemeSerializer` to use `EditorJsonUtility` instead of `JsonUtility`.

`EditorJsonUtility` can serialize `UnityEngine.Object` reference with GUID and file id while `JsonUtility` serializes it with instance id (not persistent).