### PR TITLE
Fix unstable object reference serialization

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Commandline/Editor/Internal/Deserializer/SerializableTypeBuildPropertyDeserializer.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Commandline/Editor/Internal/Deserializer/SerializableTypeBuildPropertyDeserializer.cs
@@ -3,7 +3,7 @@
 // --------------------------------------------------------------
 
 using System;
-using UnityEngine;
+using UnityEditor;
 
 namespace BuildMagicEditor.Commandline.Internal
 {
@@ -21,7 +21,9 @@ namespace BuildMagicEditor.Commandline.Internal
         /// <inheritdoc cref="IBuildPropertyDeserializer.Deserialize" />
         public object Deserialize(string value, Type valueType)
         {
-            return JsonUtility.FromJson(value, valueType);
+            var obj = Activator.CreateInstance(valueType);
+            EditorJsonUtility.FromJsonOverwrite(value, obj);
+            return obj;
         }
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindow.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/BuildMagicWindow.cs
@@ -48,7 +48,7 @@ namespace BuildMagic.Window.Editor
                 _model = CreateInstance<BuildMagicWindowModel>();
                 _model.Initialize();
                 if (_modelCache != null)
-                    JsonUtility.FromJsonOverwrite(_modelCache, _model);
+                    EditorJsonUtility.FromJsonOverwrite(_modelCache, _model);
                 _modelCache = null;
                 _model.hideFlags = HideFlags.HideInHierarchy | HideFlags.DontSaveInEditor;
             }
@@ -75,7 +75,7 @@ namespace BuildMagic.Window.Editor
 
         public void OnBeforeSerialize()
         {
-            _modelCache = JsonUtility.ToJson(_model);
+            _modelCache = EditorJsonUtility.ToJson(_model);
         }
 
         public void OnAfterDeserialize()

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/SerializableConfiguration.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/SerializableConfiguration.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection;
 using BuildMagicEditor;
+using UnityEditor;
 using UnityEngine;
 
 namespace BuildMagic.Window.Editor.Utilities
@@ -22,7 +23,11 @@ namespace BuildMagic.Window.Editor.Utilities
         private string _valueJson;
         
         private Type _cachedType;
-        
+
+        private SerializableConfiguration()
+        {
+        }
+
         public SerializableConfiguration(IBuildConfiguration configuration)
         {
             if (configuration == null)
@@ -32,7 +37,7 @@ namespace BuildMagic.Window.Editor.Utilities
             _assemblyName = type.Assembly.FullName;
             _className = type.FullName;
             _cachedType = type;
-            _valueJson = JsonUtility.ToJson(configuration, true);
+            _valueJson = EditorJsonUtility.ToJson(configuration, true);
         }
 
         public Type ConfigurationType => _cachedType;
@@ -42,8 +47,9 @@ namespace BuildMagic.Window.Editor.Utilities
         {
             if (string.IsNullOrEmpty(json))
                 throw new ArgumentException("JSON cannot be null or empty.", nameof(json));
-            
-            var obj = JsonUtility.FromJson<SerializableConfiguration>(json);
+
+            var obj = new SerializableConfiguration();
+            EditorJsonUtility.FromJsonOverwrite(json, obj);
             if (obj == null)
                 throw new InvalidOperationException("Failed to deserialize SerializableConfiguration from JSON.");
             


### PR DESCRIPTION
Fixed an issue where some serialization processes in Scheme were using JsonUtility instead of EditorJsonUtility, which occasionally prevented object references from being serialized correctly. Specifically, the serialized modelCache within BuildMagicWindow would sometimes be loaded upon editor restart, resulting in the deserialization of incorrect object references.