### PR TITLE
fix: migrate BuildMagic.Window controls to [UxmlElement] on Unity 6

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationEntryView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationEntryView.cs
@@ -9,7 +9,10 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    internal sealed class ConfigurationEntryView : PropertyField
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    internal sealed partial class ConfigurationEntryView : PropertyField
     {
         public ConfigurationType Type { get; private set; }
         public int Index { get; private set; }
@@ -39,8 +42,10 @@ namespace BuildMagic.Window.Editor.Elements
             ((IProjectSettingApplier)Configuration).ApplyProjectSetting();
         }
 
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<ConfigurationEntryView, UxmlTraits>
         {
         }
+#endif
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs
@@ -19,7 +19,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    internal partial class ConfigurationListView : BindableElement
+    public partial class ConfigurationListView : BindableElement
     {
         private readonly Label _label;
         private readonly ListView _listView;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs
@@ -16,7 +16,10 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    internal class ConfigurationListView : BindableElement
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    internal partial class ConfigurationListView : BindableElement
     {
         private readonly Label _label;
         private readonly ListView _listView;
@@ -229,6 +232,14 @@ namespace BuildMagic.Window.Editor.Elements
             entry.Unbind();
         }
 
+#if UNITY_6000_0_OR_NEWER
+        [UxmlAttribute("configuration-type")]
+        public ConfigurationType ConfigurationTypeAttribute
+        {
+            get => Type;
+            set => Type = value;
+        }
+#else
         public new class UxmlFactory : UxmlFactory<ConfigurationListView, UxmlTraits>
         {
         }
@@ -248,6 +259,7 @@ namespace BuildMagic.Window.Editor.Elements
                 derived.Type = _type.GetValueFromBag(bag, cc);
             }
         }
+#endif
 
         private interface IConfigurationFilter
         {

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/ConfigurationListView.cs
@@ -19,7 +19,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    public partial class ConfigurationListView : BindableElement
+    internal partial class ConfigurationListView : BindableElement
     {
         private readonly Label _label;
         private readonly ListView _listView;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneListEntryView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneListEntryView.cs
@@ -10,7 +10,10 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    internal sealed class LeftPaneListEntryView : BindableElement
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    internal sealed partial class LeftPaneListEntryView : BindableElement
     {
         private readonly VisualElement _autoMark;
         private readonly Label _label;
@@ -49,8 +52,10 @@ namespace BuildMagic.Window.Editor.Elements
             _autoMark.style.visibility = Value == target ? Visibility.Visible : Visibility.Hidden;
         }
 
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<LeftPaneListEntryView, UxmlTraits>
         {
         }
+#endif
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
@@ -15,7 +15,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    internal partial class LeftPaneTreeView : TreeView
+    public partial class LeftPaneTreeView : TreeView
     {
         private SerializedProperty _currentSchemeListProp;
         private BuildScheme[] _currentSchemes;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
@@ -15,7 +15,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    public partial class LeftPaneTreeView : TreeView
+    internal partial class LeftPaneTreeView : TreeView
     {
         private SerializedProperty _currentSchemeListProp;
         private BuildScheme[] _currentSchemes;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneTreeView.cs
@@ -12,7 +12,10 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    internal class LeftPaneTreeView : TreeView
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    internal partial class LeftPaneTreeView : TreeView
     {
         private SerializedProperty _currentSchemeListProp;
         private BuildScheme[] _currentSchemes;
@@ -172,6 +175,7 @@ namespace BuildMagic.Window.Editor.Elements
             Rebuild();
         }
 
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<LeftPaneTreeView, UxmlTraits>
         {
         }
@@ -179,5 +183,6 @@ namespace BuildMagic.Window.Editor.Elements
         public new class UxmlTraits : TreeView.UxmlTraits
         {
         }
+#endif
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
@@ -15,7 +15,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    public sealed partial class LeftPaneView : VisualElement, ILeftPaneView
+    internal sealed partial class LeftPaneView : VisualElement, ILeftPaneView
     {
         private readonly VisualTreeAsset _listEntryTemplate;
         private readonly LeftPaneTreeView _treeView;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
@@ -15,7 +15,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    internal sealed partial class LeftPaneView : VisualElement, ILeftPaneView
+    public sealed partial class LeftPaneView : VisualElement, ILeftPaneView
     {
         private readonly VisualTreeAsset _listEntryTemplate;
         private readonly LeftPaneTreeView _treeView;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/LeftPaneView.cs
@@ -12,7 +12,10 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    internal sealed class LeftPaneView : VisualElement, ILeftPaneView
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    internal sealed partial class LeftPaneView : VisualElement, ILeftPaneView
     {
         private readonly VisualTreeAsset _listEntryTemplate;
         private readonly LeftPaneTreeView _treeView;
@@ -81,8 +84,10 @@ namespace BuildMagic.Window.Editor.Elements
             return index >= 0 ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled;
         }
 
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<LeftPaneView, UxmlTraits>
         {
         }
+#endif
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
@@ -18,7 +18,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    internal sealed partial class RightPaneView : VisualElement, IRightPaneView
+    public sealed partial class RightPaneView : VisualElement, IRightPaneView
     {
         private readonly Button _addConfigurationButton;
         private readonly Foldout _internalPrepareConfigurationFoldout;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
@@ -18,7 +18,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    public sealed partial class RightPaneView : VisualElement, IRightPaneView
+    internal sealed partial class RightPaneView : VisualElement, IRightPaneView
     {
         private readonly Button _addConfigurationButton;
         private readonly Foldout _internalPrepareConfigurationFoldout;

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/RightPaneView.cs
@@ -15,7 +15,10 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    internal sealed class RightPaneView : VisualElement, IRightPaneView
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    internal sealed partial class RightPaneView : VisualElement, IRightPaneView
     {
         private readonly Button _addConfigurationButton;
         private readonly Foldout _internalPrepareConfigurationFoldout;
@@ -95,8 +98,10 @@ namespace BuildMagic.Window.Editor.Elements
                     : DisplayStyle.None;
         }
 
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<RightPaneView, UxmlTraits>
         {
         }
+#endif
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/SchemeLinkLabel.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/SchemeLinkLabel.cs
@@ -7,7 +7,10 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    public class SchemeLinkLabel : BindableElement, INotifyValueChanged<string>
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    public partial class SchemeLinkLabel : BindableElement, INotifyValueChanged<string>
     {
         private readonly Label _leadingLabel;
         private readonly Label _linkLabel;
@@ -29,6 +32,14 @@ namespace BuildMagic.Window.Editor.Elements
                 }, this);
         }
 
+#if UNITY_6000_0_OR_NEWER
+        [UxmlAttribute("text")]
+        public string Text
+        {
+            get => _value;
+            set => ((INotifyValueChanged<string>)this).value = value;
+        }
+#else
         #region Nested type: UxmlFactory
 
         public new class UxmlFactory : UxmlFactory<SchemeLinkLabel, UxmlTraits>
@@ -59,6 +70,7 @@ namespace BuildMagic.Window.Editor.Elements
         }
 
         #endregion
+#endif
 
         #region INotifyValueChanged<string> Members
 

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TabView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TabView.cs
@@ -7,7 +7,10 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    internal sealed class TabView : VisualElement, IDisposable
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    internal sealed partial class TabView : VisualElement, IDisposable
     {
         private const string SelectedClassName = "selected";
         private const string TabClassName = "tab";
@@ -55,9 +58,11 @@ namespace BuildMagic.Window.Editor.Elements
             GetAllTabs().ForEach(tab => { tab.UnregisterCallback<ClickEvent>(OnClick); });
         }
         
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UnityEngine.UIElements.UxmlFactory<TabView, BindableElement.UxmlTraits>
         {
         }
+#endif
 
         public void Dispose()
         {

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TabView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TabView.cs
@@ -10,7 +10,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    public sealed partial class TabView : VisualElement, IDisposable
+    internal sealed partial class TabView : VisualElement, IDisposable
     {
         private const string SelectedClassName = "selected";
         private const string TabClassName = "tab";

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TabView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TabView.cs
@@ -10,7 +10,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    internal sealed partial class TabView : VisualElement, IDisposable
+    public sealed partial class TabView : VisualElement, IDisposable
     {
         private const string SelectedClassName = "selected";
         private const string TabClassName = "tab";

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TwoPaneSplitView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TwoPaneSplitView.cs
@@ -9,7 +9,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    public sealed partial class TwoPaneSplitView : UnityEngine.UIElements.TwoPaneSplitView
+    internal sealed partial class TwoPaneSplitView : UnityEngine.UIElements.TwoPaneSplitView
     {
 #if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<TwoPaneSplitView, UxmlTraits>

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TwoPaneSplitView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TwoPaneSplitView.cs
@@ -6,10 +6,15 @@ using UnityEngine.UIElements;
 
 namespace BuildMagic.Window.Editor.Elements
 {
-    internal sealed class TwoPaneSplitView : UnityEngine.UIElements.TwoPaneSplitView
+#if UNITY_6000_0_OR_NEWER
+    [UxmlElement]
+#endif
+    internal sealed partial class TwoPaneSplitView : UnityEngine.UIElements.TwoPaneSplitView
     {
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<TwoPaneSplitView, UxmlTraits>
         {
         }
+#endif
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TwoPaneSplitView.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Elements/TwoPaneSplitView.cs
@@ -9,7 +9,7 @@ namespace BuildMagic.Window.Editor.Elements
 #if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
-    internal sealed partial class TwoPaneSplitView : UnityEngine.UIElements.TwoPaneSplitView
+    public sealed partial class TwoPaneSplitView : UnityEngine.UIElements.TwoPaneSplitView
     {
 #if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<TwoPaneSplitView, UxmlTraits>

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActions.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/IBuildSchemeContextualActions.cs
@@ -24,25 +24,27 @@ namespace BuildMagic.Window.Editor
             string subMenuPath = null)
         {
             Func<DropdownMenuAction, DropdownMenuAction.Status> getStatus = _ =>
-                getOptions().IsActive ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled;
+                getOptions() is { IsActive: true } ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled;
             var prefix = string.IsNullOrEmpty(subMenuPath) ? string.Empty : $"{subMenuPath}/";
-            menu.AppendAction($"{prefix}Apply Pre-build Now", _ => getOptions().PreBuildRequested(),
+            menu.AppendAction($"{prefix}Apply Pre-build Now", _ => getOptions()?.PreBuildRequested(),
                 getStatus);
-            menu.AppendAction($"{prefix}Build Player Now...", _ => getOptions().BuildRequested(), getStatus);
+            menu.AppendAction($"{prefix}Build Player Now...", _ => getOptions()?.BuildRequested(), getStatus);
             menu.AppendSeparator(prefix);
-            menu.AppendAction($"{prefix}Copy...", _ => getOptions().CopyCreateRequested(), getStatus);
-            menu.AppendAction($"{prefix}Inherit...", _ => getOptions().InheritCreateRequested(), getStatus);
-            menu.AppendAction($"{prefix}Remove", _ => getOptions().RemoveRequested(), getStatus);
-            menu.AppendAction($"{prefix}Unset Primary", _ => getOptions().UnsetPrimaryRequested(),
+            menu.AppendAction($"{prefix}Copy...", _ => getOptions()?.CopyCreateRequested(), getStatus);
+            menu.AppendAction($"{prefix}Inherit...", _ => getOptions()?.InheritCreateRequested(), getStatus);
+            menu.AppendAction($"{prefix}Remove", _ => getOptions()?.RemoveRequested(), getStatus);
+            menu.AppendAction($"{prefix}Unset Primary", _ => getOptions()?.UnsetPrimaryRequested(),
                 _ => getOptions() switch
                 {
+                    null => DropdownMenuAction.Status.Hidden,
                     { IsPrimary: false } => DropdownMenuAction.Status.Hidden,
                     { IsActive: false } => DropdownMenuAction.Status.Disabled,
                     _ => DropdownMenuAction.Status.Normal
                 });
-            menu.AppendAction($"{prefix}Set as Primary", _ => getOptions().SetAsPrimaryRequested(),
+            menu.AppendAction($"{prefix}Set as Primary", _ => getOptions()?.SetAsPrimaryRequested(),
                 _ => getOptions() switch
                 {
+                    null => DropdownMenuAction.Status.Hidden,
                     { IsPrimary: true } => DropdownMenuAction.Status.Hidden,
                     { IsActive: false } => DropdownMenuAction.Status.Disabled,
                     _ => DropdownMenuAction.Status.Normal

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/SubWindows/DiffWindow.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/SubWindows/DiffWindow.cs
@@ -278,9 +278,11 @@ namespace BuildMagic.Window.Editor.SubWindows
                 public const string DiffEmpty = "diff-empty";
             }
 
+#if !UNITY_6000_0_OR_NEWER
             public new class UxmlFactory : UxmlFactory<DiffRowView, UxmlTraits>
             {
             }
+#endif
         }
     }
 }

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildSchemeLoader.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic/Editor/BuildSchemeLoader.cs
@@ -78,6 +78,9 @@ namespace BuildMagicEditor
 
         public static FileSystemWatcher CreateFileSystemWatcher()
         {
+            if (Directory.Exists(BuildMagicDirectory) == false)
+                Directory.CreateDirectory(BuildMagicDirectory);
+
             var fullPath = Path.GetFullPath(BuildMagicDirectory);
             var watcher = new FileSystemWatcher
             {


### PR DESCRIPTION
## Summary
- Migrate custom VisualElements in `BuildMagic.Window` from the deprecated `UxmlFactory<T, U>` / `UxmlTraits` pattern to Unity 6's `[UxmlElement]` + `[UxmlAttribute]` API, gated by `#if UNITY_6000_0_OR_NEWER` so Unity 2022.3 LTS keeps using the legacy path.
- `SchemeLinkLabel` (`text`) and `ConfigurationListView` (`configuration-type`) gain property-style UXML attributes on Unity 6; `DiffRowView` is nested and unused from UXML, so the legacy factory is just dropped on Unity 6.
- Harden two unrelated issues surfaced by testing: `IBuildSchemeContextualActions.PopulateMenu` now tolerates a null options provider (toolbar submenus could throw before a scheme was selected), and `BuildSchemeLoader.CreateFileSystemWatcher` now creates the `ProjectSettings/BuildMagic` directory on first launch instead of throwing.

## Test plan
- [ ] Unity 6000.0+ — open Build Magic window, confirm custom elements (`TwoPaneSplitView`, `TabView`, `LeftPaneTreeView`, `LeftPaneView`, `RightPaneView`, `ConfigurationListView`, `SchemeLinkLabel`, `ConfigurationEntryView`) render and behave as before.
- [ ] Unity 6000.0+ — open Build Magic with no `ProjectSettings/BuildMagic` directory and confirm it is created without exception.
- [ ] Unity 6000.0+ — open the toolbar "Selected Build Scheme" submenu before selecting a scheme and confirm no NullReferenceException.
- [ ] Unity 2022.3 LTS — confirm the same UI still loads via the legacy `UxmlFactory` / `UxmlTraits` path.

> Note: this branch removes static built-in task `.g.cs` files via its dependency on the source generator migration. Merge after #65 (or whichever PR introduces the SG migration); on its own, Unity 6 will fail to compile because the deleted `.g.cs` files are referenced by elements this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)