### PR TITLE
Fix Unity 6.6 compilation errors

### DIFF
--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/SubWindows/SelectConfigurationDropdown.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/SubWindows/SelectConfigurationDropdown.cs
@@ -84,7 +84,7 @@ namespace BuildMagic.Window.Editor.SubWindows
             foreach (var parent in rootItems)
             {
                 sortChildrenMethod!.Invoke(parent, parameters);
-                if (parent.children.Any())
+                if (parent.GetChildren().Any())
                     continue;
                 parent.AddChild(new AdvancedDropdownItem("Configurations are not found.") {enabled = false});
             }
@@ -106,7 +106,7 @@ namespace BuildMagic.Window.Editor.SubWindows
                 for (var i = 0; i < split.Length - 1; i++)
                 {
                     var name = split[i];
-                    var child = currentParent.children.FirstOrDefault(c => c.name == name);
+                    var child = currentParent.GetChildren().FirstOrDefault(c => c.name == name);
                     if (child == null)
                     {
                         child = new AdvancedDropdownItem(name);
@@ -120,9 +120,9 @@ namespace BuildMagic.Window.Editor.SubWindows
             
             int Compare(AdvancedDropdownItem a, AdvancedDropdownItem b)
             {
-                if (a.children.Any() && !b.children.Any())
+                if (a.GetChildren().Any() && !b.GetChildren().Any())
                     return -1;
-                if (!a.children.Any() && b.children.Any())
+                if (!a.GetChildren().Any() && b.GetChildren().Any())
                     return 1;
                 
                 return string.CompareOrdinal(a.name, b.name);

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/AdvancedDropdownItemExtensions.cs
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/AdvancedDropdownItemExtensions.cs
@@ -1,0 +1,21 @@
+// --------------------------------------------------------------
+// Copyright 2026 CyberAgent, Inc.
+// --------------------------------------------------------------
+
+using System.Collections.Generic;
+using UnityEditor.IMGUI.Controls;
+
+namespace BuildMagic.Window.Editor.Utilities
+{
+    internal static class AdvancedDropdownItemExtensions
+    {
+        public static IEnumerable<AdvancedDropdownItem> GetChildren(this AdvancedDropdownItem item)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return item.childList;
+#else
+            return item.children;
+#endif
+        }
+    }
+}

--- a/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/AdvancedDropdownItemExtensions.cs.meta
+++ b/Packages/jp.co.cyberagent.buildmagic/BuildMagic.Window/Editor/Utilities/AdvancedDropdownItemExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 33798d78bef34f368c11aa2ff81f2bf2
+timeCreated: 1788417797


### PR DESCRIPTION
In Unity 6.6 (maybe 6.5?), `IEnumerable<AdvancedDropdownItem> AdvancedDropdownItem.children` has been deprecated (error), and `IReadOnlyList<AdvancedDropdownItem> AdvancedDropdownItem.childList` has been added instead. This seems to be aimed at speeding up Count and index access, but since BuildMagic rarely encounters situations where this speeds things up, we will facade it with an extension method that returns `IEnumerable<AdvancedDropdownItem>`.